### PR TITLE
Tuning GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: nuget
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
           dotnet --info
           dotnet build -c Release
       - name: Build Samples
-        if: matrix.os == 'windows-latest'
         run: msbuild samples/Samples.sln -noLogo -verbosity:minimal -restore -p:Configuration=Release
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Set up MSBuild
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1
-      # Workaround for NU1101 errors: https://github.com/actions/setup-dotnet/issues/155
-      - name: Clear NuGet cache
-        if: matrix.os == 'windows-latest'
-        run: dotnet nuget locals all --clear
       - name: Build
         run: |
           dotnet --info

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Use custom `nuget.config` instead of clear NuGet cache
- Build Samples on Ubuntu