### PR TITLE
Apply workaround for `vstest` fails on linux with .NET SDK 7.0.400

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
+      # https://github.com/microsoft/vstest/issues/4549
+      - name: Workaround for .NET SDK 7.0.400 and vstest issue
+        run: dotnet new globaljson --sdk-version 6.0.413
       - name: Set up MSBuild
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
- https://github.com/microsoft/vstest/issues/4549