### PR TITLE
Revert "Apply workaround for `vstest` fails on linux with .NET SDK 7.0.400"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
-      # https://github.com/microsoft/vstest/issues/4549
-      - name: Workaround for .NET SDK 7.0.400 and vstest issue
-        run: dotnet new globaljson --sdk-version 6.0.413
       - name: Set up MSBuild
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
This reverts commit 0790bc0a87d615112965c9ccb5f65dc71719a4e5.